### PR TITLE
fix: Replace window.onmessage with window.addEventListener() 

### DIFF
--- a/src/resources/cantoAssets/main.js
+++ b/src/resources/cantoAssets/main.js
@@ -299,7 +299,7 @@ $(document).ready(function(){
     getTokenInfo();
 
 
-    window.onmessage=function(event){
+    window.addEventListener("message", (event) => {
         var data = event.data;
         tokenInfo = data;
         if(tokenInfo && tokenInfo.accessToken && tokenInfo.accessToken.length >0)
@@ -311,7 +311,7 @@ $(document).ready(function(){
         self.find("#globalSearch input").val("");
         getImageInit(initSchme);
         }
-    };
+    });
 });
 
 function getTokenInfo(){
@@ -381,7 +381,7 @@ function addEventListener() {
         isLoadingComplete = false;
         currentImageList = [];
         cantoAPI.getFilterList(data, imageListDisplay);
-        
+
     })
     .on("click","#selectAllBtn",function(e){
         // var isAllSelectedMode = $(this).hasClass("all-selected");

--- a/src/resources/main.js
+++ b/src/resources/main.js
@@ -271,7 +271,7 @@ $(document).ready(function(){
     addEventListener();
     getTokenInfo();
 
-    window.onmessage=function(event){
+    window.addEventListener("message", (event) => {
         let tokenInfo = event.data;
 
         if(tokenInfo && tokenInfo.accessToken && tokenInfo.accessToken.length >0) {
@@ -285,7 +285,7 @@ $(document).ready(function(){
         let initSchme = $("#cantoViewBody").find(".type-font.current").data("type");
         $("#cantoViewBody").find("#globalSearch input").val("");
         getImageInit(initSchme);
-    };
+    });
 });
 
 function getTokenInfo(){

--- a/src/resources/script.js
+++ b/src/resources/script.js
@@ -32,11 +32,11 @@ $("#fields-remove-dam-asset").click(function(e) {
     let assetId = e.target.dataset.asset;
     $.ajax({type:"POST",
         url: "/canto-dam-integrator/dam-asset-removal",
-        dataType:"json", 
-        data:{ 
+        dataType:"json",
+        data:{
             "elementId": elementId,
-	        "fieldId": fieldId	
-        }, 
+	        "fieldId": fieldId
+        },
         success:function(data){
             let res = JSON.parse(data);
             if(res.status == "success") {
@@ -54,8 +54,8 @@ $("#fields-remove-dam-asset").click(function(e) {
             alert("An error occurred while attempting to remove the image, please try again later.");
         }
     });
-}); 
-    
+});
+
 $("#fields-rosas-clicker").click(function(e) {
     $modal.show();
     let fieldId = e.target.dataset.field;
@@ -102,7 +102,7 @@ cantoUC = $.fn[pluginName] = $[pluginName] = function (options, callback) {
     addEventListener();
     initCantoTag();
 
-    window.onmessage = function(event){
+    window.addEventListener("message", (event) => {
         let data = event.data;
         if(data && data.type == "getTokenInfo"){
             let receiver = document.getElementById('cantoUCFrame').contentWindow;
@@ -124,27 +124,26 @@ cantoUC = $.fn[pluginName] = $[pluginName] = function (options, callback) {
             verifyCode = data;
             // var cantoContentPage = "https://s3-us-west-2.amazonaws.com/static.dmc/universal/cantoContent.html";
             getTokenByVerifycode(verifyCode);
-            
-        }
 
-    };
+        }
+    });
 };
 
 function getTokenByVerifycode(verifyCode) {
     $.ajax({type:"POST",
-        url: "https://oauth.canto.com/oauth/api/oauth2/universal2/token", 
-        dataType:"json", 
-        data:{ 
+        url: "https://oauth.canto.com/oauth/api/oauth2/universal2/token",
+        dataType:"json",
+        data:{
             "app_id": appId,
             "grant_type": "authorization_code",
             "redirect_uri": "http://localhost:8080",
             "code": verifyCode,
             "code_verifier": timeStamp
-        }, 
+        },
         success:function(data){
             tokenInfo = data;
             getTenant(tokenInfo);
-            
+
         },
         error: function(request) {
             alert("Get token error");
@@ -153,7 +152,7 @@ function getTokenByVerifycode(verifyCode) {
 }
 function getTenant(tokenInfo) {
     $.ajax({type:"GET",
-        url: "https://oauth.canto.com:443/oauth/api/oauth2/tenant/" + tokenInfo.refreshToken, 
+        url: "https://oauth.canto.com:443/oauth/api/oauth2/tenant/" + tokenInfo.refreshToken,
         success:function(data){
             tokenInfo.tenant = data;
             var cantoContentPage = "./cantoAssets/cantoContent.html";

--- a/src/resources/test.js
+++ b/src/resources/test.js
@@ -53,7 +53,7 @@ function replaceCantoTagByImage(id, assetArray){
         settings(options);
         callback = callback;
 
-        window.onmessage=function(event){
+        window.addEventListener("message", (event) => {
             var data = event.data;
             if(data && data.type == "getTokenInfo"){
                 var receiver = document.getElementById('cantoUCFrame').contentWindow;
@@ -80,7 +80,7 @@ function replaceCantoTagByImage(id, assetArray){
                 
             }
 
-        };
+        });
     };
     function settings(options){
         env = options.env;


### PR DESCRIPTION
This ensures that we’re not *replacing* the event listener, but rather adding an additional listener, so that other listeners are not blown away